### PR TITLE
Util: include missing cstdint

### DIFF
--- a/Util/bst.h
+++ b/Util/bst.h
@@ -7,6 +7,7 @@
 
 #include "Util/assert.h"
 #include <iostream>
+#include <cstdint>
 
 namespace cwerg {
 extern uint32_t bst_stats_num_finds;

--- a/Util/parse.h
+++ b/Util/parse.h
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string_view>
 #include <vector>
+#include <cstdint>
 
 namespace cwerg {
 


### PR DESCRIPTION
Running `make` would give errors about uint32_t or uint64_t not being defined.