### PR TITLE
Include <algorithm> in code using std::sort and reverse

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
         echo
         # NOTE: the qemu-user-static causes a lot of pain because it occasionally is
         #       unavailable in CI repos
-        #       So we alternate between using the stock version and a pinnen version
+        #       So we alternate between using the stock version and a pinned version
         # PINNED VERSION
         # sudo apt-get install qemu-user-static=1:4.2-3ubuntu6.20
         # wget http://launchpadlibrarian.net/548257507/qemu-user-static_4.2-3ubuntu6.17_amd64.deb

--- a/BE/Base/reg_stats.cc
+++ b/BE/Base/reg_stats.cc
@@ -2,6 +2,7 @@
 
 #include "BE/Base/reg_stats.h"
 
+#include <algorithm>
 #include <iomanip>
 #include <map>
 

--- a/BE/CodeGenA32/regs.cc
+++ b/BE/CodeGenA32/regs.cc
@@ -1,4 +1,7 @@
 #include "BE/CodeGenA32/regs.h"
+
+#include <algorithm>
+
 #include "BE/Base/reg_alloc.h"
 #include "BE/Base/serialize.h"
 #include "BE/CodeGenA32/isel_gen.h"

--- a/BE/CodeGenA64/isel_gen.cc
+++ b/BE/CodeGenA64/isel_gen.cc
@@ -4,6 +4,7 @@
 #include "BE/CodeGenA64/isel_gen.h"
 #include "BE/Base/opcode_gen.h"
 
+#include <algorithm>
 #include <cstdint>
 
 namespace cwerg::code_gen_a64 {

--- a/BE/CodeGenA64/regs.cc
+++ b/BE/CodeGenA64/regs.cc
@@ -1,4 +1,7 @@
 #include "BE/CodeGenA64/regs.h"
+
+#include <algorithm>
+
 #include "BE/Base/cfg.h"
 #include "BE/Base/reg_alloc.h"
 #include "BE/Base/serialize.h"

--- a/BE/CodeGenX64/isel_gen.cc
+++ b/BE/CodeGenX64/isel_gen.cc
@@ -3,6 +3,7 @@
 
 #include "BE/CodeGenX64/isel_gen.h"
 
+#include <algorithm>
 #include <cstdint>
 
 #include "BE/Base/opcode_gen.h"

--- a/BE/CodeGenX64/regs.cc
+++ b/BE/CodeGenX64/regs.cc
@@ -1,4 +1,7 @@
 #include "BE/CodeGenX64/regs.h"
+
+#include <algorithm>
+
 #include "BE/Base/cfg.h"
 #include "BE/Base/reg_alloc.h"
 #include "BE/Base/serialize.h"

--- a/TestQemu/README.md
+++ b/TestQemu/README.md
@@ -77,14 +77,14 @@ aarch64-linux-gnu-objdump -d hello_barebones-a64
 qemu-arm-static  ./hello_barebones-a64
 ```
 
-Often it useful to see how a compiler translates a certain C expression.
+Often it is useful to see how a compiler translates a certain C expression.
 Assuming `test.c` contains code with that expression. Run
 ```
 aarch64-linux-gnu-gcc-8 test.c -c -O3  -o xxx.o ; aarch64-linux-gnu-objdump -D xxx.o
 ```
 to see the result.
 
-Qemu can also used to generated traces which can be useful for debugging:
+Qemu can also be used to generate traces which can be useful for debugging:
 
 General purpose reg contents only
 ```

--- a/getting_started.md
+++ b/getting_started.md
@@ -9,7 +9,7 @@ based Linux distributions.
 
 First you need to install (cross) tool chains and emulators.
 
-Cwerg requires C++17 compatible compilers and Python 3.10 or higher.
+Cwerg requires C++20 compatible compilers and Python 3.10 or higher.
 ```
 sudo apt install cmake
 sudo apt install gcc g++

--- a/why_python.md
+++ b/why_python.md
@@ -49,8 +49,8 @@ Implementing the everything twice has additional benefits:
 The initial plan was to provide a C port but C in 2020 felt like an exercise in masochism
 and so the C port morphed into a C++ port.
 The hope is to offer plain C bindings on top of it. To facilitate this the C++ stays clear
-of exception and virtual functions and only uses a fairly limited part of STL.
-All the basic data structure use custom containers.
+of exceptions and virtual functions and only uses a fairly limited part of STL.
+All the basic data structures use custom containers.
 
 
 ## C++ Entanglement


### PR DESCRIPTION
Building the compiler using cmake, `cmake -B build` and `make -C build`, I get various errors because of missing functions, mostly `std::sort` and `std::reverse` a few times:

```
Cwerg/BE/CodeGenA32/regs.cc: In Funktion »void cwerg::code_gen_a32::{anonymous}::RunLinearScan(cwerg::base::Bbl, cwerg::base::Fun, bool, std::vector<cwerg::base::LiveRange>*, uint32_t, uint32_t, uint32_t, uint32_t)«:
Cwerg/BE/CodeGenA32/regs.cc:174:8: Fehler: »sort« ist kein Element von »std«; meinten Sie »qsort«?
  174 |   std::sort(begin(ordered), end(ordered),
      |        ^~~~
      |        qsort
```

Here is the system information:

```
Tool Versions
python3 -V
Python 3.12.10
gcc -v
Reading specs from /usr/lib64/gcc/x86_64-slackware-linux/14.2.0/specs
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-slackware-linux/14.2.0/lto-wrapper
Target: x86_64-slackware-linux
Configured with: ../configure --prefix=/usr --libdir=/usr/lib64 --mandir=/usr/man --infodir=/usr/info --enable-shared --enable-bootstrap --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust --enable-threads=posix --enable-checking=release --with-system-zlib --enable-libstdcxx-dual-abi --with-default-libstdcxx-abi=new --disable-libstdcxx-pch --disable-libunwind-exceptions --enable-__cxa_atexit --disable-libssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-plugin --enable-lto --disable-install-libiberty --disable-werror --with-gnu-ld --with-isl --verbose --with-arch-directory=amd64 --disable-gtktest --enable-clocale=gnu --with-arch=x86-64 --enable-multilib --target=x86_64-slackware-linux --build=x86_64-slackware-linux --host=x86_64-slackware-linux
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 14.2.0 (GCC) 
g++ -v
Reading specs from /usr/lib64/gcc/x86_64-slackware-linux/14.2.0/specs
COLLECT_GCC=g++
COLLECT_LTO_WRAPPER=/usr/libexec/gcc/x86_64-slackware-linux/14.2.0/lto-wrapper
Target: x86_64-slackware-linux
Configured with: ../configure --prefix=/usr --libdir=/usr/lib64 --mandir=/usr/man --infodir=/usr/info --enable-shared --enable-bootstrap --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust --enable-threads=posix --enable-checking=release --with-system-zlib --enable-libstdcxx-dual-abi --with-default-libstdcxx-abi=new --disable-libstdcxx-pch --disable-libunwind-exceptions --enable-__cxa_atexit --disable-libssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-plugin --enable-lto --disable-install-libiberty --disable-werror --with-gnu-ld --with-isl --verbose --with-arch-directory=amd64 --disable-gtktest --enable-clocale=gnu --with-arch=x86-64 --enable-multilib --target=x86_64-slackware-linux --build=x86_64-slackware-linux --host=x86_64-slackware-linux
Thread model: posix
Supported LTO compression algorithms: zlib zstd
gcc version 14.2.0 (GCC) 
clang -v
clang version 20.1.3
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-slackware-linux/14.2.0
Found candidate GCC installation: /usr/bin/../lib64/gcc/x86_64-slackware-linux/14.2.0
Selected GCC installation: /usr/bin/../lib64/gcc/x86_64-slackware-linux/14.2.0
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Selected multilib: .;@m64
clang++ -v
clang version 20.1.3
Target: x86_64-unknown-linux-gnu
Thread model: posix
InstalledDir: /usr/bin
Found candidate GCC installation: /usr/bin/../lib/gcc/x86_64-slackware-linux/14.2.0
Found candidate GCC installation: /usr/bin/../lib64/gcc/x86_64-slackware-linux/14.2.0
Selected GCC installation: /usr/bin/../lib64/gcc/x86_64-slackware-linux/14.2.0
Candidate multilib: .;@m64
Candidate multilib: 32;@m32
Selected multilib: .;@m64
```

Unfortunately I couldn't run `make` because of the missing `qemu-*-static` binaries:

> /bin/sh: line 1: qemu-arm-static: command not found

(I suppose, this is userspace emulation, and qemu calls them `qemu-*`, without the `-static` suffix by default).

I also changed a few places in the documentation, that look like a typo to me.