### PR TITLE
Adding CI workflow to build docker dev-env image

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -1,0 +1,244 @@
+name: DevEnv Docker Image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - devenv-v*
+  workflow_dispatch:
+
+concurrency:
+  # Cancel unfinished CI/CD runs if a new run starts on the same branch.
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  PLATFORMS: linux/amd64,linux/arm64
+  TEMP_IMAGE_NAME: localhost:5000/${{ github.repository }}/dev-env:ci
+  GHCR_IMAGE_NAME: ghcr.io/${{ github.repository }}/dev-env
+
+jobs:
+  check_build:
+    name: Check if we should build a new docker image.
+    runs-on: ubuntu-24.04
+    outputs:
+      do_build: ${{ steps.check.outputs.do_build }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          # Only metadata of 2 most recent commits is necessary below.
+          fetch-depth: 2
+          sparse-checkout: nix-da
+
+      - name: Check if the situation warrants a build`
+        id: check
+        run: |
+          if [[ $GITHUB_REF == refs/tags/devenv-v* ]]; then
+            echo "Got tag ${GITHUB_REF#refs/tags/} - will build"
+            echo "do_build=true" >> "$GITHUB_OUTPUT"
+          elif [[ "$GITHUB_EVENT_NAME" == "workflow_dispatch" ]]; then
+            echo "Manual start - will build"
+            echo "do_build=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only HEAD~1 | grep -q '^docker/'; then
+            echo "Committed docker/* files - will build"
+            echo "do_build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No relevant changes - won't build"
+            echo "do_build=false" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build and test docker image
+    needs: [check_build]
+    if: needs.check_build.outputs.do_build == 'true'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read       # Required for the 'actions/checkout' step
+      packages: write      # Allows pushing/writing to GHCR
+
+    services:
+      registry:
+        # Ephemeral docker registry for storing images between build and test.
+        image: registry:2
+        ports:
+          - 5000:5000
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Bats and bats libs
+        id: setup-bats
+        uses: bats-core/bats-action@3.0.1
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: ${{ env.PLATFORMS }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: Login to GitHub Container Registry (GHCR)
+        uses: docker/login-action@v3
+        with:
+          # Persistent docker registry for publishing the image.
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Cleanup image names
+        run: |
+          # Container registry names must be lowercase.
+          {
+            echo "TEMP_IMAGE_NAME=${TEMP_IMAGE_NAME,,}"
+            echo "GHCR_IMAGE_NAME=${GHCR_IMAGE_NAME,,}"
+          } >> "$GITHUB_ENV"
+
+      - name: Prepare image metadata
+        id: meta
+        run: |
+          PUSH_TO_GHCR=false
+          # Determine the Docker container tags.
+          TAGS=""
+
+          if [[ $GITHUB_REF == refs/tags/devenv-v* ]]; then
+            PUSH_TO_GHCR=true
+            # Git tags are used as docker image tags with 'devenv-' stripped.
+            VERSION=${GITHUB_REF#refs/tags/devenv-}
+            TAGS="${{ env.GHCR_IMAGE_NAME }}:${VERSION}"
+
+            if [[ $VERSION =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+               # Apply semantic version (semver) expansion, i.e., latest X.Y.Z
+               # also becomes X.Y and X
+               V=${VERSION:1}
+               MAJOR_MINOR=${V%.*}
+               MAJOR=${MAJOR_MINOR%.*}
+               TAGS="$TAGS,${{ env.GHCR_IMAGE_NAME }}:v${MAJOR_MINOR}"
+               TAGS="$TAGS,${{ env.GHCR_IMAGE_NAME }}:v${MAJOR}"
+            fi
+
+          elif [[ $GITHUB_REF == 'refs/heads/master' ]]; then
+            PUSH_TO_GHCR=true
+            # Git main branch commits are tagged with docker's default 'latest'
+            # tag.
+            VERSION=latest
+            TAGS="${{ env.GHCR_IMAGE_NAME }}:${VERSION}"
+          fi
+
+          # Version number in image metadata is either the tag version (with v
+          # prefix stripped), or the git sha for "latest" images.
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            IMAGE_VERSION=${VERSION#v}
+          else
+            IMAGE_VERSION="git-${GITHUB_SHA:0:7}"
+          fi
+
+          echo "::group::Image metadata"
+          echo "PUSH_TO_GHCR=${PUSH_TO_GHCR}"
+          echo "VERSION=${VERSION}"
+          echo "TAGS=${TAGS}"
+          echo "IMAGE_VERSION=${IMAGE_VERSION}"
+          echo "::endgroup::"
+
+          {
+            echo "push_to_ghcr=${PUSH_TO_GHCR}"
+            echo "image_version=${IMAGE_VERSION}"
+            echo "tags=${TAGS}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Build development environment image
+        uses: docker/build-push-action@v5
+        with:
+          context: docker
+          platforms: ${{ env.PLATFORMS }}
+          push: true
+          tags: ${{ env.TEMP_IMAGE_NAME }}
+          build-args: |
+            IMAGE_VERSION=${{ steps.meta.outputs.image_version }}
+
+      - name: Inspect image manifest
+        id: inspect
+        run: |
+          # Get the metadata of all platform images from the multi-platform
+          # manifest of the above build.
+          docker buildx imagetools inspect ${{ env.TEMP_IMAGE_NAME }}
+          echo "raw=$(docker buildx imagetools inspect --raw \
+            ${{ env.TEMP_IMAGE_NAME }} \
+            | tr -d '\n')" >> "$GITHUB_OUTPUT"
+
+      - name: Test image
+        env:
+          BATS_LIB_PATH: ${{ steps.setup-bats.outputs.lib-path }}
+        run: |
+          # Do a test build on all architectures.
+          # Get digest and architecture of each manifest in multi-platform
+          # image.
+          digests=(${{ join(
+            fromJSON(steps.inspect.outputs.raw).manifests.*.digest,
+            ' '
+          ) }})
+          architectures=(${{ join(
+            fromJSON(steps.inspect.outputs.raw).manifests.*.platform.
+                architecture,
+            ' '
+          ) }})
+          oss=(${{ join(
+            fromJSON(steps.inspect.outputs.raw).manifests.*.platform.os,
+            ' '
+          ) }})
+          if [[ "${#digests[@]}" -ne "${#architectures[@]}" || \
+                "${#architectures[@]}" -ne "${#oss[@]}" ]]; then
+            echo "::error::Digest, arch, and os array lengths do not match:" \
+                 "[${oss[*]}] [${architectures[*]}] [${digests[*]}]"
+            exit 1
+          fi
+          for ((i=0; i<${#digests[@]}; i++)); do
+            digest="${digests[i]}"
+            arch="${architectures[i]}"
+            os="${oss[i]}"
+            echo "Digest: ${digest}"
+            echo "Architecture: ${arch}"
+            # The multi-platform docker image contains a bunch of manifests, but
+            # only the ones that have an valid architecture are manifests of
+            # platform sub-images we can actually run.
+            if [[ "${arch}" == 'unknown' ]]; then
+              echo '... skipping metadata image'
+              continue
+            fi
+            # Run the test suite on one architecture.
+            export DOCKER_IMAGE="${{ env.TEMP_IMAGE_NAME }}@${digest}"
+            echo "Running tests on image ${DOCKER_IMAGE}..."
+            docker pull "${DOCKER_IMAGE}"
+            export PLATFORM="${os}/${arch}"
+            docker run --platform "${PLATFORM}" --rm -v .:/Cwerg \
+                "${DOCKER_IMAGE}" \
+                sh -c 'echo Testing image on $(uname -m)...'
+            if [[ "${arch}" != 'amd64' ]]; then
+              # Don't run slow tests under emulation.
+              args='--filter-tags !slow'
+            fi
+            # Don't parallelize - test order within .bats file is required.
+            # shellcheck disable=SC2086 # Double quote to prevent word splitting
+            bats -j 1 ${args} --trace docker/tests
+          done
+
+      - name: Push to GHCR
+        if: steps.meta.outputs.push_to_ghcr == 'true'
+        run: |
+          # Split the comma-separated tags and format them as arguments
+          IFS=',' read -ra TAG_ARRAY <<< "${{ steps.meta.outputs.tags }}"
+          TAG_ARGS=""
+          for tag in "${TAG_ARRAY[@]}"; do
+            TAG_ARGS="$TAG_ARGS -t $tag"
+          done
+
+          # Use imagetools create to copy the multi-platform image from the
+          # local registry to GHCR.
+          # This avoids rebuilding the image and ensures the exact image tested
+          # is pushed.
+          # shellcheck disable=SC2086
+          docker buildx imagetools create $TAG_ARGS ${{ env.TEMP_IMAGE_NAME }}

--- a/.github/workflows/ghcr-cleanup.yml
+++ b/.github/workflows/ghcr-cleanup.yml
@@ -1,0 +1,36 @@
+name: Cleanup GHCR
+
+on:
+  schedule:
+    - cron: '56 4 * * 0' # Every Sunday at 4:56 am
+  workflow_dispatch:
+
+concurrency:
+  # Cancel unfinished cleanup runs if a new run starts.
+  group: clean-ghcr
+  cancel-in-progress: true
+
+jobs:
+  cleanup:
+    name: Clean GitHub Container Registry
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Get image name
+        run: |
+          REPO_NAME="${GITHUB_REPOSITORY#*/}"
+          # Container registry names must be lowercase.
+          echo "IMAGE_NAME=${REPO_NAME,,}/dev-env" >> "$GITHUB_ENV"
+
+      - name: Cleanup container images
+        uses: dataaxiom/ghcr-cleanup-action@v1
+        with:
+          packages: ${{ env.IMAGE_NAME }}
+          older-than: 7 days
+          # Overwriting tag `:latest` will untag the previous `:latest` image.
+          delete-untagged: true
+          delete-ghost-images: true
+          delete-partial-images: true
+          delete-orphaned-images: true
+          dry-run: false

--- a/docker/tests/setup_suite.bash
+++ b/docker/tests/setup_suite.bash
@@ -1,0 +1,9 @@
+load utils
+
+setup_suite() {
+  setup_all
+}
+
+teardown_suite() {
+  teardown_all
+}

--- a/docker/tests/test_devenv.bats
+++ b/docker/tests/test_devenv.bats
@@ -1,0 +1,96 @@
+#!/bin/env bats
+
+load utils
+
+@test "Checking that python3 exists..." {
+  run_in_container which python3
+  assert_success
+}
+
+@test "Checking that python3 version is >= 3.10..." {
+  run_in_container python3 --version
+  assert_success
+  assert_output --regexp "Python 3\.[0-9]{2,}\.[0-9]+"
+}
+
+@test "Checking that g++ exists..." {
+  run_in_container which g++
+  assert_success
+}
+
+@test "Checking that g++ runs..." {
+  run_in_container g++ --version
+  assert_success
+}
+
+@test "Checking that g++ supports c++20..." {
+  local src="${TESTS_WORKDIR}/test_c++20.cpp"
+  local exe="${TESTS_WORKDIR}/test_c++20.exe"
+
+  cat - >"${src}" <<EOF
+    #include <iostream>
+
+    int main() {
+      std::cout << "C++20 supported!" << std::endl;
+      return 0;
+    }
+EOF
+  # First build it.
+  run_in_container sh -c \
+    "cd /Cwerg; g++ -std=c++20 ${src} -o ${exe}"
+  assert_success
+  assert_exists "${exe}"
+
+  # Then run it.
+  run_in_container "/Cwerg/${exe}"
+  assert_success
+  assert_output 'C++20 supported!'
+}
+
+@test "Checking that /Cwerg was mounted correctly..." {
+  # Though if it weren't, it would be an internal test infrastructure failure,
+  # not a failure of the container that we're trying to check.
+  run_in_container test -f /Cwerg/cwerg.py
+  assert_success
+}
+
+# Now move on to more elaborate tests.
+
+test_src='FE/TestData/hello_world_test.cw'
+exe_py="${TESTS_WORKDIR}/hello.py.exe"
+exe_cxx="${TESTS_WORKDIR}/hello.c++.exe"
+
+@test "Checking that we can run Python Cwerg..." {
+  run_in_container sh -c \
+    "cd Cwerg; ./cwerg.py -be py -fe py ${test_src} ${exe_py}"
+  assert_success
+  assert_exists "${exe_py}"
+}
+
+@test "Checking that we can run Python compiled binary..." {
+  run_in_container "/Cwerg/${exe_py}"
+  assert_success
+  assert_output --partial "hello world"
+}
+
+# bats test_tags=slow
+@test "Checking that we can build C++ Cwerg..." {
+  run_in_container sh -c "cd Cwerg; make build_compiler"
+  assert_success
+  assert_exists build/compiler.exe
+}
+
+# bats test_tags=slow
+@test "Checking that we can run C++ Cwerg..." {
+
+  run_in_container sh -c "cd Cwerg; ./cwerg.py ${test_src} ${exe_cxx}"
+  assert_success
+  assert_exists "${exe_cxx}"
+}
+
+# bats test_tags=slow
+@test "Checking that we can run C++ compiled binary..." {
+  run_in_container "/Cwerg/${exe_cxx}"
+  assert_success
+  assert_output --partial "hello world"
+}

--- a/docker/tests/utils.bash
+++ b/docker/tests/utils.bash
@@ -1,0 +1,54 @@
+# Load bats support libraries.
+bats_load_library 'bats-support'
+bats_load_library 'bats-assert'
+bats_load_library 'bats-file'
+
+debug() {
+  echo '# --- DEBUG: ' "$@" >&3
+}
+
+force_error() {
+  echo '# --- ERROR: ' "$@" >&3
+  exit 1
+}
+
+setup_all() {
+  [[ -n "${DOCKER_IMAGE}" ]] \
+    || force_error 'DOCKER_IMAGE environment variable not defined'
+
+  # Make sure the docker image exists.
+  docker inspect "${DOCKER_IMAGE}" > /dev/null \
+    || force_error "DOCKER_IMAGE '${DOCKER_IMAGE}' does not exist"
+
+  # Create workdir to store temporary stuff. Not all mktemp take a destination
+  # directory willingly, so we work around that.
+  TESTS_WORKDIR_ORIG="$(mktemp)"
+  TESTS_WORKDIR=$(basename "${TESTS_WORKDIR_ORIG}")
+  mkdir "${TESTS_WORKDIR}"
+  export TESTS_WORKDIR
+  # Save build directory, if there is one (for local testing).
+  BUILD_SAVED="build-${TESTS_WORKDIR}"
+  if [[ -e build ]]; then
+    mv build "${BUILD_SAVED}"
+  fi
+}
+
+teardown_all() {
+  # Restore saved build directory.
+  if [[ -e "${BUILD_SAVED}" ]]; then
+    rm -rf build
+    mv "${BUILD_SAVED}" build
+  fi
+  # Remove temporary work directories.
+  rm -rf "${TESTS_WORKDIR}" "${TESTS_WORKDIR_ORIG}"
+}
+
+# Run a command in the container.
+run_in_container() {
+  if [[ -n "${PLATFORM}" ]]; then
+    args="--platform ${PLATFORM}"
+  fi
+  echo "run_in_container: $*"
+  # shellcheck disable=SC2086 # Double quote to prevent word splitting
+  run docker run ${args} --rm -v .:/Cwerg "${DOCKER_IMAGE}" "$@"
+}

--- a/quick_start_user.md
+++ b/quick_start_user.md
@@ -25,14 +25,22 @@ provided docker container.
   of the compiler you need to install the following packages:
   `make cmake g++ libunwind-dev`.
 * **Docker container**: You need to have the `docker` package installed on your
-  host. Then build the docker container that encapsulates a ready configured
-  development environment:
-
-  `docker build -t cwerg-dev-env Cwerg/docker`
+  host. The docker container encapsulates a ready configured development
+  environment.
+  * Use the pre-built docker container (for amd64 and arm64):
+    ```
+    IMAGE='ghcr.io/robertmuth/cwerg/dev-env:latest'
+    docker pull $IMAGE
+    ```
+  * Build your own docker container:
+    ```
+    IMAGE='cwerg-dev-env'
+    docker build -t $IMAGE Cwerg/docker
+    ```
 
   Start a shell in the container:
 
-  `docker run -it --rm -v Cwerg:/Cwerg cwerg-dev-env`
+  `docker run -it --rm -v Cwerg:/Cwerg $IMAGE`
 
   Then run the command lines indicated below inside this shell.
 


### PR DESCRIPTION
Added a CI/CD workflow that builds the development environment docker image (cwerg-dev-env). It is a multi-platform image for amd64 and arm64.

* It first builds the image for all platforms, pushing it onto a local ephemeral container registry.
* It then runs a test suite on the built image to make sure it is viable.
* Finally, if the tests pass, it publishes the image to the Github Container Registry (GHCR) for public access at `ghcr.io/robertmuth/cwerg/dev-env`

When images are built and published:
* From any commits to the main branch that touch the `docker/*` subdirectory, assuming that this constitutes changes to the development environment that need to be reflected in a new version of the image. All other changes to the git repository are ignored, i.e., changes to the Cwerg compiler don't trigger image builds. Such images are tagged `latest` and metadata labeled with the git SHA.
  * When the CI pipeline is triggered manually, it is handled similar to a commit to the main branch.
* Tag pushes to the git repository of the form `devenv-vX.Y.Z` also trigger image builds. Such images are tagged with the version number `vX.Y.Z` (and `vX.Y`, `vX`) and also metadata labeled the same.

Repushing images with the same tag (`latest`) results in the previously such tagged image to become untagged. A separate CI workflow garbage collects such images once a week (or if manually triggered).

The user quick start documentation has been updated.